### PR TITLE
chore: update @types/react and @types/react-dom to version 19.1.5

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -63,6 +63,8 @@
         "@radix-ui/react-label": "^2.1.6",
         "@react-three/drei": "^10.0.8",
         "@react-three/fiber": "^9.1.2",
+        "@types/react": "^19.1.5",
+        "@types/react-dom": "^19.1.5",
         "color-thief-browser": "^2.0.2",
         "crypto-js": "^4.2.0",
         "three": "^0.176.0"

--- a/frontend/src/components/Topbar.tsx
+++ b/frontend/src/components/Topbar.tsx
@@ -1,4 +1,4 @@
-import { SignedOut, UserButton, SignInButton } from "@clerk/clerk-react";
+import { UserButton, SignInButton, useAuth } from "@clerk/clerk-react";
 import { LayoutDashboardIcon, Search } from "lucide-react";
 import { Link } from "react-router-dom";
 import { useState, useEffect } from "react";
@@ -10,6 +10,7 @@ import { buttonVariants } from "./ui/button";
 const Topbar = () => {
 	const [searchTerm, setSearchTerm] = useState('');
 	const { isAdmin } = useAuthStore();
+	const { isSignedIn } = useAuth(); // Add this line
 	console.log({ isAdmin });
 
 	useEffect(() => {
@@ -47,9 +48,10 @@ const Topbar = () => {
 					</Link>
 				)}
 
-				<SignedOut>
-					<SignInButton mode="modal" />
-				</SignedOut>
+				{
+					// Conditionally render SignInButton if user is signed out
+					!isSignedIn && <SignInButton mode="modal" />
+				}
 
 				<UserButton />
 			</div>

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -8,17 +8,21 @@ const labelVariants = cva(
   "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
 )
 
+interface LabelProps extends React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>,
+  VariantProps<typeof labelVariants> {
+    className?: string;
+  }
+
 const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
-  VariantProps<typeof labelVariants>
+  LabelProps
 >(({ className, ...props }, ref) => (
   <LabelPrimitive.Root
     ref={ref}
     className={cn(labelVariants(), className)}
     {...props}
   />
-))
+));
 Label.displayName = LabelPrimitive.Root.displayName
 
 export { Label }

--- a/frontend/src/pages/admin/AdminPage.tsx
+++ b/frontend/src/pages/admin/AdminPage.tsx
@@ -11,13 +11,14 @@ const AdminPage = () => {
 	const { isAdmin, isLoading } = useAuthStore();
 	const [showAddArtistForm, setShowAddArtistForm] = useState(false); // State to control form visibility
 
-	const { fetchAlbums, fetchSongs, fetchStats } = useMusicStore();
+	const { fetchAlbums, fetchSongs, fetchStats, fetchArtists } = useMusicStore(); // Destructure fetchArtists
 
 	useEffect(() => {
 		fetchAlbums();
 		fetchSongs();
 		fetchStats();
-	}, [fetchAlbums, fetchSongs, fetchStats]);
+		fetchArtists(); // Fetch artists on component mount
+	}, [fetchAlbums, fetchSongs, fetchStats, fetchArtists]);
 
 	if (!isAdmin && !isLoading) return <div>Unauthorized</div>;
 
@@ -34,15 +35,17 @@ const AdminPage = () => {
 			<h3 className="text-lg font-semibold text-white mb-4">1. Create a new Artist profile that doesn't exist</h3>
 			<div className="mb-4">
 				{!showAddArtistForm && (
-					<Button variant="outline" onClick={() => setShowAddArtistForm(true)}>
+					<Button
+						className="bg-purple-600 text-white hover:bg-purple-700"
+						onClick={() => setShowAddArtistForm(true)}
+					>
 						Add New Artist
 					</Button>
 				)}
 				{showAddArtistForm && (
 					<AddArtistForm
 						onArtistAdded={() => {
-							// TODO: Refresh artist list after adding a new artist
-							console.log("Artist added, refresh list if needed.");
+							fetchArtists(); // Refresh artist list after adding a new artist
 							setShowAddArtistForm(false); // Hide form after adding
 						}}
 						onCancel={() => setShowAddArtistForm(false)} // Hide form on cancel

--- a/frontend/src/pages/admin/components/AddArtistDialog.tsx
+++ b/frontend/src/pages/admin/components/AddArtistDialog.tsx
@@ -1,44 +1,22 @@
 import React, { useState } from 'react';
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
-import { axiosInstance } from "@/lib/axios";
-import toast from "react-hot-toast";
+import AddArtistForm from './AddArtistForm'; // Import AddArtistForm
 
 interface AddArtistDialogProps {
   onArtistAdded: () => void;
 }
 
 const AddArtistDialog: React.FC<AddArtistDialogProps> = ({ onArtistAdded }) => {
-  const [name, setName] = useState('');
-  const [profilePhotoUrl, setProfilePhotoUrl] = useState('');
-  const [about, setAbout] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setIsLoading(true);
-    try {
-      const response = await axiosInstance.post("/api/admin/artists", {
-        name,
-        profilePhotoUrl,
-        about,
-      });
-      toast.success("Artist created successfully!");
-      setName('');
-      setProfilePhotoUrl('');
-      setAbout('');
-      setIsOpen(false);
-      onArtistAdded(); // Notify parent component
-    } catch (error: any) {
-      console.error("Error creating artist:", error);
-      toast.error("Failed to create artist: " + (error.response?.data?.message || error.message));
-    } finally {
-      setIsLoading(false);
-    }
+  const handleArtistAdded = () => {
+    setIsOpen(false); // Close dialog on successful artist creation
+    onArtistAdded();
+  };
+
+  const handleCancel = () => {
+    setIsOpen(false); // Close dialog on cancel
   };
 
   return (
@@ -46,49 +24,11 @@ const AddArtistDialog: React.FC<AddArtistDialogProps> = ({ onArtistAdded }) => {
       <DialogTrigger asChild>
         <Button variant="outline">Add New Artist</Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[425px] bg-zinc-900 text-white border-zinc-800">
+      <DialogContent className="sm:max-w-[600px] bg-zinc-900 text-white border-zinc-800"> {/* Adjusted max-w */}
         <DialogHeader>
           <DialogTitle className="text-white">Add New Artist</DialogTitle>
         </DialogHeader>
-        <form onSubmit={handleSubmit} className="grid gap-4 py-4">
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="name" className="text-right text-zinc-400">
-              Name
-            </Label>
-            <Input
-              id="name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              className="col-span-3 bg-zinc-800 border-zinc-700 text-white"
-              required
-            />
-          </div>
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="profilePhotoUrl" className="text-right text-zinc-400">
-              Photo URL
-            </Label>
-            <Input
-              id="profilePhotoUrl"
-              value={profilePhotoUrl}
-              onChange={(e) => setProfilePhotoUrl(e.target.value)}
-              className="col-span-3 bg-zinc-800 border-zinc-700 text-white"
-            />
-          </div>
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="about" className="text-right text-zinc-400">
-              About
-            </Label>
-            <Textarea
-              id="about"
-              value={about}
-              onChange={(e) => setAbout(e.target.value)}
-              className="col-span-3 bg-zinc-800 border-zinc-700 text-white"
-            />
-          </div>
-          <Button type="submit" className="mt-4 bg-green-500 hover:bg-green-600 text-black" disabled={isLoading}>
-            {isLoading ? 'Creating...' : 'Create Artist'}
-          </Button>
-        </form>
+        <AddArtistForm onArtistAdded={handleArtistAdded} onCancel={handleCancel} />
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/pages/admin/components/AddArtistForm.tsx
+++ b/frontend/src/pages/admin/components/AddArtistForm.tsx
@@ -128,7 +128,7 @@ const AddArtistForm: React.FC<AddArtistFormProps> = ({ onArtistAdded, onCancel }
           <Button type="button" variant="outline" onClick={onCancel} disabled={isLoading}>
             Cancel
           </Button>
-          <Button type="submit" className="bg-green-500 hover:bg-green-600 text-black" disabled={isLoading}>
+          <Button type="submit" className="bg-purple-500 hover:bg-purple-600 text-white" disabled={isLoading}>
             {isLoading ? 'Creating...' : 'Create Artist'}
           </Button>
         </div>

--- a/frontend/src/stores/useMusicStore.ts
+++ b/frontend/src/stores/useMusicStore.ts
@@ -1,11 +1,12 @@
 import { axiosInstance } from "@/lib/axios";
-import { Album, Song, Stats } from "@/types";
+import { Album, Song, Stats, Artist } from "@/types"; // Import Artist
 import toast from "react-hot-toast";
 import { create } from "zustand";
 
 interface MusicStore {
 	songs: Song[];
 	albums: Album[];
+	artists: Artist[]; // Add artists state
 	isLoading: boolean;
 	error: string | null;
 	currentAlbum: Album | null;
@@ -21,6 +22,7 @@ interface MusicStore {
 	fetchTrendingSongs: () => Promise<void>;
 	fetchStats: () => Promise<void>;
 	fetchSongs: () => Promise<void>;
+	fetchArtists: () => Promise<void>; // Add fetchArtists
 	deleteSong: (id: string) => Promise<void>;
 	deleteAlbum: (id: string) => Promise<void>;
 }
@@ -28,6 +30,7 @@ interface MusicStore {
 export const useMusicStore = create<MusicStore>((set) => ({
 	albums: [],
 	songs: [],
+	artists: [], // Initialize artists state
 	isLoading: false,
 	error: null,
 	currentAlbum: null,
@@ -156,6 +159,18 @@ export const useMusicStore = create<MusicStore>((set) => ({
 			set({ trendingSongs: response.data });
 		} catch (error: any) {
 			set({ error: error.response.data.message });
+		} finally {
+			set({ isLoading: false });
+		}
+	},
+
+	fetchArtists: async () => {
+		set({ isLoading: true, error: null });
+		try {
+			const response = await axiosInstance.get("/api/artists");
+			set({ artists: response.data }); // Set artists state
+		} catch (error: any) {
+			set({ error: error.message });
 		} finally {
 			set({ isLoading: false });
 		}

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -293,13 +293,21 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/react": {
-			"version": "19.1.4",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.4.tgz",
-			"integrity": "sha512-EB1yiiYdvySuIITtD5lhW4yPyJ31RkJkkDw794LaQYrxCSaQV/47y5o1FMC4zF9ZyjUjzJMZwbovEnT5yHTW6g==",
+			"version": "19.1.5",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.5.tgz",
+			"integrity": "sha512-piErsCVVbpMMT2r7wbawdZsq4xMvIAhQuac2gedQHysu1TZYEigE6pnFfgZT+/jQnrRuF5r+SHzuehFjfRjr4g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"csstype": "^3.0.2"
+			}
+		},
+		"node_modules/@types/react-dom": {
+			"version": "19.1.5",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.5.tgz",
+			"integrity": "sha512-CMCjrWucUBZvohgZxkjd6S9h0nZxXjzus6yDfUb+xLxYM7VvjKNH1tQrE9GWLql1XoOP4/Ds3bwFqShHUYraGg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "^19.0.0"
 			}
 		},
 		"node_modules/@types/react-reconciler": {
@@ -471,8 +479,7 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
 			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/detect-gpu": {
 			"version": "5.0.70",

--- a/node_modules/@types/react-dom/LICENSE
+++ b/node_modules/@types/react-dom/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/node_modules/@types/react-dom/README.md
+++ b/node_modules/@types/react-dom/README.md
@@ -1,0 +1,16 @@
+# Installation
+> `npm install --save @types/react-dom`
+
+# Summary
+This package contains type definitions for react-dom (https://react.dev/).
+
+# Details
+Files were exported from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-dom.
+
+### Additional Details
+ * Last updated: Tue, 13 May 2025 10:38:36 GMT
+ * Dependencies: none
+ * Peer dependencies: [@types/react](https://npmjs.com/package/@types/react)
+
+# Credits
+These definitions were written by [Asana](https://asana.com), [AssureSign](http://www.assuresign.com), [Microsoft](https://microsoft.com), [MartynasZilinskas](https://github.com/MartynasZilinskas), [Josh Rutherford](https://github.com/theruther4d), [Jessica Franco](https://github.com/Jessidhia), and [Sebastian Silbermann](https://github.com/eps1lon).

--- a/node_modules/@types/react-dom/canary.d.ts
+++ b/node_modules/@types/react-dom/canary.d.ts
@@ -1,0 +1,32 @@
+/**
+ * These are types for things that are present in the upcoming React 18 release.
+ *
+ * Once React 18 is released they can just be moved to the main index file.
+ *
+ * To load the types declared here in an actual project, there are three ways. The easiest one,
+ * if your `tsconfig.json` already has a `"types"` array in the `"compilerOptions"` section,
+ * is to add `"react-dom/canary"` to the `"types"` array.
+ *
+ * Alternatively, a specific import syntax can to be used from a typescript file.
+ * This module does not exist in reality, which is why the {} is important:
+ *
+ * ```ts
+ * import {} from 'react-dom/canary'
+ * ```
+ *
+ * It is also possible to include it through a triple-slash reference:
+ *
+ * ```ts
+ * /// <reference types="react-dom/canary" />
+ * ```
+ *
+ * Either the import or the reference only needs to appear once, anywhere in the project.
+ */
+
+// See https://github.com/facebook/react/blob/main/packages/react-dom/index.js to see how the exports are declared,
+// but confirm with published source code (e.g. https://unpkg.com/react-dom@canary) that these exports end up in the published code
+
+import React = require("react");
+import ReactDOM = require(".");
+
+export {};

--- a/node_modules/@types/react-dom/client.d.ts
+++ b/node_modules/@types/react-dom/client.d.ts
@@ -1,0 +1,105 @@
+/**
+ * WARNING: This entrypoint is only available starting with `react-dom@18.0.0-rc.1`
+ */
+
+// See https://github.com/facebook/react/blob/main/packages/react-dom/client.js to see how the exports are declared,
+
+import React = require("react");
+
+export {};
+
+declare const REACT_FORM_STATE_SIGIL: unique symbol;
+export interface ReactFormState {
+    [REACT_FORM_STATE_SIGIL]: never;
+}
+
+export interface HydrationOptions {
+    formState?: ReactFormState | null;
+    /**
+     * Prefix for `useId`.
+     */
+    identifierPrefix?: string;
+    onUncaughtError?:
+        | ((error: unknown, errorInfo: { componentStack?: string | undefined }) => void)
+        | undefined;
+    onRecoverableError?: (error: unknown, errorInfo: ErrorInfo) => void;
+    onCaughtError?:
+        | ((
+            error: unknown,
+            errorInfo: {
+                componentStack?: string | undefined;
+                errorBoundary?: React.Component<unknown> | undefined;
+            },
+        ) => void)
+        | undefined;
+}
+
+export interface RootOptions {
+    /**
+     * Prefix for `useId`.
+     */
+    identifierPrefix?: string;
+    onUncaughtError?:
+        | ((error: unknown, errorInfo: { componentStack?: string | undefined }) => void)
+        | undefined;
+    onRecoverableError?: (error: unknown, errorInfo: ErrorInfo) => void;
+    onCaughtError?:
+        | ((
+            error: unknown,
+            errorInfo: {
+                componentStack?: string | undefined;
+                errorBoundary?: React.Component<unknown> | undefined;
+            },
+        ) => void)
+        | undefined;
+}
+
+export interface ErrorInfo {
+    componentStack?: string;
+}
+
+export interface Root {
+    render(children: React.ReactNode): void;
+    unmount(): void;
+}
+
+/**
+ * Different release channels declare additional types of ReactNode this particular release channel accepts.
+ * App or library types should never augment this interface.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_CREATE_ROOT_CONTAINERS {}
+
+export type Container =
+    | Element
+    | DocumentFragment
+    | Document
+    | DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_CREATE_ROOT_CONTAINERS[
+        keyof DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_CREATE_ROOT_CONTAINERS
+    ];
+
+/**
+ * createRoot lets you create a root to display React components inside a browser DOM node.
+ *
+ * @see {@link https://react.dev/reference/react-dom/client/createRoot API Reference for `createRoot`}
+ */
+export function createRoot(container: Container, options?: RootOptions): Root;
+
+/**
+ * Same as `createRoot()`, but is used to hydrate a container whose HTML contents were rendered by ReactDOMServer.
+ *
+ * React will attempt to attach event listeners to the existing markup.
+ *
+ * **Example Usage**
+ *
+ * ```jsx
+ * hydrateRoot(document.querySelector('#root'), <App />)
+ * ```
+ *
+ * @see https://reactjs.org/docs/react-dom-client.html#hydrateroot
+ */
+export function hydrateRoot(
+    container: Element | Document,
+    initialChildren: React.ReactNode,
+    options?: HydrationOptions,
+): Root;

--- a/node_modules/@types/react-dom/experimental.d.ts
+++ b/node_modules/@types/react-dom/experimental.d.ts
@@ -1,0 +1,86 @@
+/**
+ * These are types for things that are present in the `experimental` builds of React but not yet
+ * on a stable build.
+ *
+ * Once they are promoted to stable they can just be moved to the main index file.
+ *
+ * To load the types declared here in an actual project, there are three ways. The easiest one,
+ * if your `tsconfig.json` already has a `"types"` array in the `"compilerOptions"` section,
+ * is to add `"react-dom/experimental"` to the `"types"` array.
+ *
+ * Alternatively, a specific import syntax can to be used from a typescript file.
+ * This module does not exist in reality, which is why the {} is important:
+ *
+ * ```ts
+ * import {} from 'react-dom/experimental'
+ * ```
+ *
+ * It is also possible to include it through a triple-slash reference:
+ *
+ * ```ts
+ * /// <reference types="react-dom/experimental" />
+ * ```
+ *
+ * Either the import or the reference only needs to appear once, anywhere in the project.
+ */
+
+// See https://github.com/facebook/react/blob/main/packages/react-dom/index.experimental.js to see how the exports are declared,
+// but confirm with published source code (e.g. https://unpkg.com/react-dom@experimental) that these exports end up in the published code
+
+import React = require("react");
+import ReactDOM = require("./canary");
+
+export {};
+
+declare const UNDEFINED_VOID_ONLY: unique symbol;
+type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
+
+declare module "." {
+}
+
+declare module "react" {
+    interface ViewTransitionPseudoElement extends Animatable {
+        getComputedStyle: () => CSSStyleDeclaration;
+    }
+
+    interface ViewTransitionInstance {
+        group: ViewTransitionPseudoElement;
+        imagePair: ViewTransitionPseudoElement;
+        old: ViewTransitionPseudoElement;
+        new: ViewTransitionPseudoElement;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface GestureProvider extends AnimationTimeline {}
+
+    // @enableFragmentRefs
+    interface FragmentInstance {
+        blur: () => void;
+        focus: (focusOptions?: FocusOptions | undefined) => void;
+        focusLast: (focusOptions?: FocusOptions | undefined) => void;
+        observeUsing(observer: IntersectionObserver | ResizeObserver): void;
+        unobserveUsing(observer: IntersectionObserver | ResizeObserver): void;
+        getClientRects(): Array<DOMRect>;
+        getRootNode(getRootNodeOptions?: GetRootNodeOptions | undefined): Document | ShadowRoot | FragmentInstance;
+        addEventListener(
+            type: string,
+            listener: EventListener,
+            optionsOrUseCapture?: Parameters<Element["addEventListener"]>[2],
+        ): void;
+        removeEventListener(
+            type: string,
+            listener: EventListener,
+            optionsOrUseCapture?: Parameters<Element["removeEventListener"]>[2],
+        ): void;
+    }
+}
+
+declare module "./client" {
+    type TransitionIndicatorCleanup = () => VoidOrUndefinedOnly;
+    interface RootOptions {
+        onDefaultTransitionIndicator?: (() => void | TransitionIndicatorCleanup) | undefined;
+    }
+    interface HydrationOptions {
+        onDefaultTransitionIndicator?: (() => void | TransitionIndicatorCleanup) | undefined;
+    }
+}

--- a/node_modules/@types/react-dom/index.d.ts
+++ b/node_modules/@types/react-dom/index.d.ts
@@ -1,0 +1,128 @@
+// NOTE: Users of the `experimental` builds of React should add a reference
+// to 'react-dom/experimental' in their project. See experimental.d.ts's top comment
+// for reference and documentation on how exactly to do it.
+
+export as namespace ReactDOM;
+
+import { Key, ReactNode, ReactPortal } from "react";
+
+export function createPortal(
+    children: ReactNode,
+    container: Element | DocumentFragment,
+    key?: Key | null,
+): ReactPortal;
+
+export const version: string;
+
+export function flushSync<R>(fn: () => R): R;
+
+export function unstable_batchedUpdates<A, R>(callback: (a: A) => R, a: A): R;
+export function unstable_batchedUpdates<R>(callback: () => R): R;
+
+export interface FormStatusNotPending {
+    pending: false;
+    data: null;
+    method: null;
+    action: null;
+}
+
+export interface FormStatusPending {
+    pending: true;
+    data: FormData;
+    method: string;
+    action: string | ((formData: FormData) => void | Promise<void>);
+}
+
+export type FormStatus = FormStatusPending | FormStatusNotPending;
+
+export function useFormStatus(): FormStatus;
+
+export function useFormState<State>(
+    action: (state: Awaited<State>) => State | Promise<State>,
+    initialState: Awaited<State>,
+    permalink?: string,
+): [state: Awaited<State>, dispatch: () => void, isPending: boolean];
+export function useFormState<State, Payload>(
+    action: (state: Awaited<State>, payload: Payload) => State | Promise<State>,
+    initialState: Awaited<State>,
+    permalink?: string,
+): [state: Awaited<State>, dispatch: (payload: Payload) => void, isPending: boolean];
+
+export function prefetchDNS(href: string): void;
+
+export interface PreconnectOptions {
+    // Don't create a helper type.
+    // It would have to be in module scope to be inlined in TS tooltips.
+    // But then it becomes part of the public API.
+    // TODO: Upstream to microsoft/TypeScript-DOM-lib-generator -> w3c/webref
+    // since the spec has a notion of a dedicated type: https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attribute
+    crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+}
+export function preconnect(href: string, options?: PreconnectOptions): void;
+
+export type PreloadAs =
+    | "audio"
+    | "document"
+    | "embed"
+    | "fetch"
+    | "font"
+    | "image"
+    | "object"
+    | "track"
+    | "script"
+    | "style"
+    | "video"
+    | "worker";
+export interface PreloadOptions {
+    as: PreloadAs;
+    crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+    fetchPriority?: "high" | "low" | "auto" | undefined;
+    // TODO: These should only be allowed with `as: 'image'` but it's not trivial to write tests against the full TS support matrix.
+    imageSizes?: string | undefined;
+    imageSrcSet?: string | undefined;
+    integrity?: string | undefined;
+    type?: string | undefined;
+    nonce?: string | undefined;
+    referrerPolicy?: ReferrerPolicy | undefined;
+    media?: string | undefined;
+}
+export function preload(href: string, options?: PreloadOptions): void;
+
+// https://html.spec.whatwg.org/multipage/links.html#link-type-modulepreload
+export type PreloadModuleAs = RequestDestination;
+export interface PreloadModuleOptions {
+    /**
+     * @default "script"
+     */
+    as: PreloadModuleAs;
+    crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+    integrity?: string | undefined;
+    nonce?: string | undefined;
+}
+export function preloadModule(href: string, options?: PreloadModuleOptions): void;
+
+export type PreinitAs = "script" | "style";
+export interface PreinitOptions {
+    as: PreinitAs;
+    crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+    fetchPriority?: "high" | "low" | "auto" | undefined;
+    precedence?: string | undefined;
+    integrity?: string | undefined;
+    nonce?: string | undefined;
+}
+export function preinit(href: string, options?: PreinitOptions): void;
+
+// Will be expanded to include all of https://github.com/tc39/proposal-import-attributes
+export type PreinitModuleAs = "script";
+export interface PreinitModuleOptions {
+    /**
+     * @default "script"
+     */
+    as?: PreinitModuleAs;
+    crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+    integrity?: string | undefined;
+    nonce?: string | undefined;
+}
+export function preinitModule(href: string, options?: PreinitModuleOptions): void;
+
+export function requestFormReset(form: HTMLFormElement): void;

--- a/node_modules/@types/react-dom/package.json
+++ b/node_modules/@types/react-dom/package.json
@@ -1,0 +1,93 @@
+{
+    "name": "@types/react-dom",
+    "version": "19.1.5",
+    "description": "TypeScript definitions for react-dom",
+    "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-dom",
+    "license": "MIT",
+    "contributors": [
+        {
+            "name": "Asana",
+            "url": "https://asana.com"
+        },
+        {
+            "name": "AssureSign",
+            "url": "http://www.assuresign.com"
+        },
+        {
+            "name": "Microsoft",
+            "url": "https://microsoft.com"
+        },
+        {
+            "name": "MartynasZilinskas",
+            "githubUsername": "MartynasZilinskas",
+            "url": "https://github.com/MartynasZilinskas"
+        },
+        {
+            "name": "Josh Rutherford",
+            "githubUsername": "theruther4d",
+            "url": "https://github.com/theruther4d"
+        },
+        {
+            "name": "Jessica Franco",
+            "githubUsername": "Jessidhia",
+            "url": "https://github.com/Jessidhia"
+        },
+        {
+            "name": "Sebastian Silbermann",
+            "githubUsername": "eps1lon",
+            "url": "https://github.com/eps1lon"
+        }
+    ],
+    "main": "",
+    "types": "index.d.ts",
+    "exports": {
+        ".": {
+            "types": {
+                "default": "./index.d.ts"
+            }
+        },
+        "./client": {
+            "types": {
+                "default": "./client.d.ts"
+            }
+        },
+        "./canary": {
+            "types": {
+                "default": "./canary.d.ts"
+            }
+        },
+        "./server": {
+            "types": {
+                "default": "./server.d.ts"
+            }
+        },
+        "./static": {
+            "types": {
+                "default": "./static.d.ts"
+            }
+        },
+        "./experimental": {
+            "types": {
+                "default": "./experimental.d.ts"
+            }
+        },
+        "./test-utils": {
+            "types": {
+                "default": "./test-utils/index.d.ts"
+            }
+        },
+        "./package.json": "./package.json"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
+        "directory": "types/react-dom"
+    },
+    "scripts": {},
+    "dependencies": {},
+    "peerDependencies": {
+        "@types/react": "^19.0.0"
+    },
+    "typesPublisherContentHash": "8a1684fb26e8b99b1cec59dc73a6f538f51e7fb6c25e0110d94115caf867e8f9",
+    "typeScriptVersion": "5.1"
+}

--- a/node_modules/@types/react-dom/server.d.ts
+++ b/node_modules/@types/react-dom/server.d.ts
@@ -1,0 +1,114 @@
+// forward declarations
+declare global {
+    namespace NodeJS {
+        // eslint-disable-next-line @typescript-eslint/no-empty-interface
+        interface ReadableStream {}
+
+        // eslint-disable-next-line @typescript-eslint/no-empty-interface
+        interface WritableStream {}
+    }
+
+    /**
+     * Stub for https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface AbortSignal {}
+
+    /**
+     * Stub for https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream
+     */
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface ReadableStream {}
+}
+
+import { ReactNode } from "react";
+import { ErrorInfo } from "./client";
+
+export type BootstrapScriptDescriptor = {
+    src: string;
+    integrity?: string | undefined;
+    crossOrigin?: string | undefined;
+};
+
+export interface RenderToPipeableStreamOptions {
+    identifierPrefix?: string;
+    namespaceURI?: string;
+    nonce?: string;
+    bootstrapScriptContent?: string;
+    bootstrapScripts?: Array<string | BootstrapScriptDescriptor>;
+    bootstrapModules?: Array<string | BootstrapScriptDescriptor>;
+    progressiveChunkSize?: number;
+    onShellReady?: () => void;
+    onShellError?: (error: unknown) => void;
+    onAllReady?: () => void;
+    onError?: (error: unknown, errorInfo: ErrorInfo) => string | void;
+}
+
+export interface PipeableStream {
+    abort: (reason?: unknown) => void;
+    pipe: <Writable extends NodeJS.WritableStream>(destination: Writable) => Writable;
+}
+
+export interface ServerOptions {
+    identifierPrefix?: string;
+}
+
+/**
+ * Only available in the environments with [Node.js Streams](https://nodejs.dev/learn/nodejs-streams).
+ *
+ * @see [API](https://reactjs.org/docs/react-dom-server.html#rendertopipeablestream)
+ *
+ * @param children
+ * @param options
+ */
+export function renderToPipeableStream(children: ReactNode, options?: RenderToPipeableStreamOptions): PipeableStream;
+
+/**
+ * Render a React element to its initial HTML. This should only be used on the server.
+ * React will return an HTML string. You can use this method to generate HTML on the server
+ * and send the markup down on the initial request for faster page loads and to allow search
+ * engines to crawl your pages for SEO purposes.
+ *
+ * If you call `ReactDOMClient.hydrateRoot()` on a node that already has this server-rendered markup,
+ * React will preserve it and only attach event handlers, allowing you
+ * to have a very performant first-load experience.
+ */
+export function renderToString(element: ReactNode, options?: ServerOptions): string;
+
+/**
+ * Similar to `renderToString`, except this doesn't create extra DOM attributes
+ * such as `data-reactid`, that React uses internally. This is useful if you want
+ * to use React as a simple static page generator, as stripping away the extra
+ * attributes can save lots of bytes.
+ */
+export function renderToStaticMarkup(element: ReactNode, options?: ServerOptions): string;
+
+export interface RenderToReadableStreamOptions {
+    identifierPrefix?: string;
+    namespaceURI?: string;
+    nonce?: string;
+    bootstrapScriptContent?: string;
+    bootstrapScripts?: Array<string | BootstrapScriptDescriptor>;
+    bootstrapModules?: Array<string | BootstrapScriptDescriptor>;
+    progressiveChunkSize?: number;
+    signal?: AbortSignal;
+    onError?: (error: unknown, errorInfo: ErrorInfo) => string | void;
+}
+
+export interface ReactDOMServerReadableStream extends ReadableStream {
+    allReady: Promise<void>;
+}
+
+/**
+ * Only available in the environments with [Web Streams](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) (this includes browsers, Deno, and some modern edge runtimes).
+ *
+ * @see [API](https://reactjs.org/docs/react-dom-server.html#rendertoreadablestream)
+ */
+export function renderToReadableStream(
+    children: ReactNode,
+    options?: RenderToReadableStreamOptions,
+): Promise<ReactDOMServerReadableStream>;
+
+export const version: string;
+
+export as namespace ReactDOMServer;

--- a/node_modules/@types/react-dom/static.d.ts
+++ b/node_modules/@types/react-dom/static.d.ts
@@ -1,0 +1,78 @@
+// forward declarations
+declare global {
+    namespace NodeJS {
+        // eslint-disable-next-line @typescript-eslint/no-empty-interface
+        interface ReadableStream {}
+    }
+
+    /**
+     * Stub for https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface AbortSignal {}
+
+    /**
+     * Stub for https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream
+     */
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface ReadableStream<R = any> {}
+
+    /**
+     * Stub for https://developer.mozilla.org/en-US/docs/Web/API/Uint8Array
+     */
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface Uint8Array {}
+}
+
+import { ReactNode } from "react";
+import { ErrorInfo } from "./client";
+
+export type BootstrapScriptDescriptor = {
+    src: string;
+    integrity?: string | undefined;
+    crossOrigin?: string | undefined;
+};
+
+export interface PrerenderOptions {
+    bootstrapScriptContent?: string;
+    bootstrapScripts?: Array<string | BootstrapScriptDescriptor>;
+    bootstrapModules?: Array<string | BootstrapScriptDescriptor>;
+    identifierPrefix?: string;
+    namespaceURI?: string;
+    onError?: (error: unknown, errorInfo: ErrorInfo) => string | void;
+    progressiveChunkSize?: number;
+    signal?: AbortSignal;
+}
+
+export interface PrerenderResult {
+    prelude: ReadableStream<Uint8Array>;
+}
+
+/**
+ * Only available in the environments with [Web Streams](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) (this includes browsers, Deno, and some modern edge runtimes).
+ *
+ * @see [API](https://react.dev/reference/react-dom/static/prerender)
+ */
+export function prerender(
+    reactNode: ReactNode,
+    options?: PrerenderOptions,
+): Promise<PrerenderResult>;
+
+export interface PrerenderToNodeStreamResult {
+    prelude: NodeJS.ReadableStream;
+}
+
+/**
+ * Only available in the environments with [Node.js Streams](https://nodejs.dev/learn/nodejs-streams).
+ *
+ * @see [API](https://react.dev/reference/react-dom/static/prerenderToNodeStream)
+ *
+ * @param children
+ * @param options
+ */
+export function prerenderToNodeStream(
+    reactNode: ReactNode,
+    options?: PrerenderOptions,
+): Promise<PrerenderToNodeStreamResult>;
+
+export const version: string;

--- a/node_modules/@types/react-dom/test-utils/index.d.ts
+++ b/node_modules/@types/react-dom/test-utils/index.d.ts
@@ -1,0 +1,7 @@
+export {};
+
+export {
+    /**
+     * @deprecated Import `act` from `react` instead.
+     */ act,
+} from "react";

--- a/node_modules/@types/react/README.md
+++ b/node_modules/@types/react/README.md
@@ -8,7 +8,7 @@ This package contains type definitions for react (https://react.dev/).
 Files were exported from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react.
 
 ### Additional Details
- * Last updated: Mon, 12 May 2025 19:32:10 GMT
+ * Last updated: Wed, 21 May 2025 10:38:15 GMT
  * Dependencies: [csstype](https://npmjs.com/package/csstype)
 
 # Credits

--- a/node_modules/@types/react/global.d.ts
+++ b/node_modules/@types/react/global.d.ts
@@ -13,6 +13,7 @@ interface ClipboardEvent extends Event {}
 interface CompositionEvent extends Event {}
 interface DragEvent extends Event {}
 interface FocusEvent extends Event {}
+interface InputEvent extends Event {}
 interface KeyboardEvent extends Event {}
 interface MouseEvent extends Event {}
 interface TouchEvent extends Event {}

--- a/node_modules/@types/react/index.d.ts
+++ b/node_modules/@types/react/index.d.ts
@@ -11,6 +11,7 @@ type NativeClipboardEvent = ClipboardEvent;
 type NativeCompositionEvent = CompositionEvent;
 type NativeDragEvent = DragEvent;
 type NativeFocusEvent = FocusEvent;
+type NativeInputEvent = InputEvent;
 type NativeKeyboardEvent = KeyboardEvent;
 type NativeMouseEvent = MouseEvent;
 type NativeTouchEvent = TouchEvent;
@@ -2003,6 +2004,10 @@ declare namespace React {
         target: EventTarget & T;
     }
 
+    interface InputEvent<T = Element> extends SyntheticEvent<T, NativeInputEvent> {
+        data: string;
+    }
+
     export type ModifierKey =
         | "Alt"
         | "AltGraph"
@@ -2123,6 +2128,7 @@ declare namespace React {
     type FocusEventHandler<T = Element> = EventHandler<FocusEvent<T>>;
     type FormEventHandler<T = Element> = EventHandler<FormEvent<T>>;
     type ChangeEventHandler<T = Element> = EventHandler<ChangeEvent<T>>;
+    type InputEventHandler<T = Element> = EventHandler<InputEvent<T>>;
     type KeyboardEventHandler<T = Element> = EventHandler<KeyboardEvent<T>>;
     type MouseEventHandler<T = Element> = EventHandler<MouseEvent<T>>;
     type TouchEventHandler<T = Element> = EventHandler<TouchEvent<T>>;
@@ -2181,7 +2187,7 @@ declare namespace React {
         // Form Events
         onChange?: FormEventHandler<T> | undefined;
         onChangeCapture?: FormEventHandler<T> | undefined;
-        onBeforeInput?: FormEventHandler<T> | undefined;
+        onBeforeInput?: InputEventHandler<T> | undefined;
         onBeforeInputCapture?: FormEventHandler<T> | undefined;
         onInput?: FormEventHandler<T> | undefined;
         onInputCapture?: FormEventHandler<T> | undefined;

--- a/node_modules/@types/react/package.json
+++ b/node_modules/@types/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@types/react",
-    "version": "19.1.4",
+    "version": "19.1.5",
     "description": "TypeScript definitions for react",
     "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react",
     "license": "MIT",
@@ -205,6 +205,6 @@
         "csstype": "^3.0.2"
     },
     "peerDependencies": {},
-    "typesPublisherContentHash": "314c1f08fc88f627aff39c5d112d447dc52e3174262c641967d172bd4f0b1f36",
+    "typesPublisherContentHash": "d2687e6a6a92b300c5f3ff4789f9080f45116bb0bdd8d9bb7b94443fa00cfa00",
     "typeScriptVersion": "5.1"
 }

--- a/node_modules/@types/react/ts5.0/global.d.ts
+++ b/node_modules/@types/react/ts5.0/global.d.ts
@@ -13,6 +13,7 @@ interface ClipboardEvent extends Event {}
 interface CompositionEvent extends Event {}
 interface DragEvent extends Event {}
 interface FocusEvent extends Event {}
+interface InputEvent extends Event {}
 interface KeyboardEvent extends Event {}
 interface MouseEvent extends Event {}
 interface TouchEvent extends Event {}

--- a/node_modules/@types/react/ts5.0/index.d.ts
+++ b/node_modules/@types/react/ts5.0/index.d.ts
@@ -11,6 +11,7 @@ type NativeClipboardEvent = ClipboardEvent;
 type NativeCompositionEvent = CompositionEvent;
 type NativeDragEvent = DragEvent;
 type NativeFocusEvent = FocusEvent;
+type NativeInputEvent = InputEvent;
 type NativeKeyboardEvent = KeyboardEvent;
 type NativeMouseEvent = MouseEvent;
 type NativeTouchEvent = TouchEvent;
@@ -2002,6 +2003,10 @@ declare namespace React {
         target: EventTarget & T;
     }
 
+    interface InputEvent<T = Element> extends SyntheticEvent<T, NativeInputEvent> {
+        data: string;
+    }
+
     export type ModifierKey =
         | "Alt"
         | "AltGraph"
@@ -2122,6 +2127,7 @@ declare namespace React {
     type FocusEventHandler<T = Element> = EventHandler<FocusEvent<T>>;
     type FormEventHandler<T = Element> = EventHandler<FormEvent<T>>;
     type ChangeEventHandler<T = Element> = EventHandler<ChangeEvent<T>>;
+    type InputEventHandler<T = Element> = EventHandler<InputEvent<T>>;
     type KeyboardEventHandler<T = Element> = EventHandler<KeyboardEvent<T>>;
     type MouseEventHandler<T = Element> = EventHandler<MouseEvent<T>>;
     type TouchEventHandler<T = Element> = EventHandler<TouchEvent<T>>;
@@ -2180,7 +2186,7 @@ declare namespace React {
         // Form Events
         onChange?: FormEventHandler<T> | undefined;
         onChangeCapture?: FormEventHandler<T> | undefined;
-        onBeforeInput?: FormEventHandler<T> | undefined;
+        onBeforeInput?: InputEventHandler<T> | undefined;
         onBeforeInputCapture?: FormEventHandler<T> | undefined;
         onInput?: FormEventHandler<T> | undefined;
         onInputCapture?: FormEventHandler<T> | undefined;

--- a/node_modules/@types/react/ts5.0/v18/global.d.ts
+++ b/node_modules/@types/react/ts5.0/v18/global.d.ts
@@ -13,6 +13,7 @@ interface ClipboardEvent extends Event {}
 interface CompositionEvent extends Event {}
 interface DragEvent extends Event {}
 interface FocusEvent extends Event {}
+interface InputEvent extends Event {}
 interface KeyboardEvent extends Event {}
 interface MouseEvent extends Event {}
 interface TouchEvent extends Event {}

--- a/node_modules/@types/react/ts5.0/v18/index.d.ts
+++ b/node_modules/@types/react/ts5.0/v18/index.d.ts
@@ -12,6 +12,7 @@ type NativeClipboardEvent = ClipboardEvent;
 type NativeCompositionEvent = CompositionEvent;
 type NativeDragEvent = DragEvent;
 type NativeFocusEvent = FocusEvent;
+type NativeInputEvent = InputEvent;
 type NativeKeyboardEvent = KeyboardEvent;
 type NativeMouseEvent = MouseEvent;
 type NativeTouchEvent = TouchEvent;
@@ -2242,6 +2243,10 @@ declare namespace React {
         target: EventTarget & T;
     }
 
+    interface InputEvent<T = Element> extends SyntheticEvent<T, NativeInputEvent> {
+        data: string;
+    }
+
     export type ModifierKey =
         | "Alt"
         | "AltGraph"
@@ -2357,6 +2362,7 @@ declare namespace React {
     type FocusEventHandler<T = Element> = EventHandler<FocusEvent<T>>;
     type FormEventHandler<T = Element> = EventHandler<FormEvent<T>>;
     type ChangeEventHandler<T = Element> = EventHandler<ChangeEvent<T>>;
+    type InputEventHandler<T = Element> = EventHandler<InputEvent<T>>;
     type KeyboardEventHandler<T = Element> = EventHandler<KeyboardEvent<T>>;
     type MouseEventHandler<T = Element> = EventHandler<MouseEvent<T>>;
     type TouchEventHandler<T = Element> = EventHandler<TouchEvent<T>>;
@@ -2414,7 +2420,7 @@ declare namespace React {
         // Form Events
         onChange?: FormEventHandler<T> | undefined;
         onChangeCapture?: FormEventHandler<T> | undefined;
-        onBeforeInput?: FormEventHandler<T> | undefined;
+        onBeforeInput?: InputEventHandler<T> | undefined;
         onBeforeInputCapture?: FormEventHandler<T> | undefined;
         onInput?: FormEventHandler<T> | undefined;
         onInputCapture?: FormEventHandler<T> | undefined;

--- a/node_modules/@types/react/ts5.0/v18/ts5.0/global.d.ts
+++ b/node_modules/@types/react/ts5.0/v18/ts5.0/global.d.ts
@@ -13,6 +13,7 @@ interface ClipboardEvent extends Event {}
 interface CompositionEvent extends Event {}
 interface DragEvent extends Event {}
 interface FocusEvent extends Event {}
+interface InputEvent extends Event {}
 interface KeyboardEvent extends Event {}
 interface MouseEvent extends Event {}
 interface TouchEvent extends Event {}

--- a/node_modules/@types/react/ts5.0/v18/ts5.0/index.d.ts
+++ b/node_modules/@types/react/ts5.0/v18/ts5.0/index.d.ts
@@ -12,6 +12,7 @@ type NativeClipboardEvent = ClipboardEvent;
 type NativeCompositionEvent = CompositionEvent;
 type NativeDragEvent = DragEvent;
 type NativeFocusEvent = FocusEvent;
+type NativeInputEvent = InputEvent;
 type NativeKeyboardEvent = KeyboardEvent;
 type NativeMouseEvent = MouseEvent;
 type NativeTouchEvent = TouchEvent;
@@ -2243,6 +2244,10 @@ declare namespace React {
         target: EventTarget & T;
     }
 
+    interface InputEvent<T = Element> extends SyntheticEvent<T, NativeInputEvent> {
+        data: string;
+    }
+
     export type ModifierKey =
         | "Alt"
         | "AltGraph"
@@ -2358,6 +2363,7 @@ declare namespace React {
     type FocusEventHandler<T = Element> = EventHandler<FocusEvent<T>>;
     type FormEventHandler<T = Element> = EventHandler<FormEvent<T>>;
     type ChangeEventHandler<T = Element> = EventHandler<ChangeEvent<T>>;
+    type InputEventHandler<T = Element> = EventHandler<InputEvent<T>>;
     type KeyboardEventHandler<T = Element> = EventHandler<KeyboardEvent<T>>;
     type MouseEventHandler<T = Element> = EventHandler<MouseEvent<T>>;
     type TouchEventHandler<T = Element> = EventHandler<TouchEvent<T>>;
@@ -2415,7 +2421,7 @@ declare namespace React {
         // Form Events
         onChange?: FormEventHandler<T> | undefined;
         onChangeCapture?: FormEventHandler<T> | undefined;
-        onBeforeInput?: FormEventHandler<T> | undefined;
+        onBeforeInput?: InputEventHandler<T> | undefined;
         onBeforeInputCapture?: FormEventHandler<T> | undefined;
         onInput?: FormEventHandler<T> | undefined;
         onInputCapture?: FormEventHandler<T> | undefined;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
 				"@radix-ui/react-label": "^2.1.6",
 				"@react-three/drei": "^10.0.8",
 				"@react-three/fiber": "^9.1.2",
+				"@types/react": "^19.1.5",
+				"@types/react-dom": "^19.1.5",
 				"color-thief-browser": "^2.0.2",
 				"crypto-js": "^4.2.0",
 				"three": "^0.176.0"
@@ -310,13 +312,21 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/react": {
-			"version": "19.1.4",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.4.tgz",
-			"integrity": "sha512-EB1yiiYdvySuIITtD5lhW4yPyJ31RkJkkDw794LaQYrxCSaQV/47y5o1FMC4zF9ZyjUjzJMZwbovEnT5yHTW6g==",
+			"version": "19.1.5",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.5.tgz",
+			"integrity": "sha512-piErsCVVbpMMT2r7wbawdZsq4xMvIAhQuac2gedQHysu1TZYEigE6pnFfgZT+/jQnrRuF5r+SHzuehFjfRjr4g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"csstype": "^3.0.2"
+			}
+		},
+		"node_modules/@types/react-dom": {
+			"version": "19.1.5",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.5.tgz",
+			"integrity": "sha512-CMCjrWucUBZvohgZxkjd6S9h0nZxXjzus6yDfUb+xLxYM7VvjKNH1tQrE9GWLql1XoOP4/Ds3bwFqShHUYraGg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "^19.0.0"
 			}
 		},
 		"node_modules/@types/react-reconciler": {
@@ -488,8 +498,7 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
 			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/detect-gpu": {
 			"version": "5.0.70",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
 		"@radix-ui/react-label": "^2.1.6",
 		"@react-three/drei": "^10.0.8",
 		"@react-three/fiber": "^9.1.2",
+		"@types/react": "^19.1.5",
+		"@types/react-dom": "^19.1.5",
 		"color-thief-browser": "^2.0.2",
 		"crypto-js": "^4.2.0",
 		"three": "^0.176.0"


### PR DESCRIPTION
- Updated @types/react from 19.1.4 to 19.1.5
- Updated @types/react-dom to 19.1.5
- Added InputEvent interface to global.d.ts and index.d.ts
- Updated event handler types to include InputEventHandler
- Modified onBeforeInput event handler type to use InputEventHandler
- Updated README.md and LICENSE files for @types/react-dom
- Added canary, client, experimental, server, and static type definitions for @types/react-dom
- Added test-utils for @types/react-dom